### PR TITLE
ESP32-PICOへのSPIFFS書き込みの失敗の修正 #27

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,12 @@ else
 PORT0 = $(shell echo $(PORT))
 endif
 
+ifeq ("$(BAUD)","")
+BAUD0 = 921600
+else
+BAUD0 = $(shell echo $(BAUD))
+endif
+
 # include
 ifneq ("$(IDF_PATH)","")
 include $(IDF_PATH)/make/project.mk
@@ -51,8 +57,8 @@ spiffs:
 	$(MRBC) -o ./spiffs/mrbc/slave.mrbc -E ./src/slave.rb
 	@echo $(MKSPIFFS) -c ./spiffs/mrbc -p 256 -b 4096 -s $(SPIFFS_DATA_TABLE_SIZE) ./spiffs/mrbc.spiffs.bin
 	$(MKSPIFFS) -c ./spiffs/mrbc -p 256 -b 4096 -s $(SPIFFS_DATA_TABLE_SIZE) ./spiffs/mrbc.spiffs.bin
-	@echo $(ESPTOOL) --chip esp32 --baud 921600 --port $(PORT0) --before default_reset --after hard_reset write_flash -z --flash_mode qio --flash_freq 80m --flash_size detect $(SPIFFS_DATA_OFFSET) ./spiffs/mrbc.spiffs.bin
-	$(ESPTOOL) --chip esp32 --baud 921600 --port $(PORT0) --before default_reset --after hard_reset write_flash -z --flash_mode qio --flash_freq 80m --flash_size detect $(SPIFFS_DATA_OFFSET) ./spiffs/mrbc.spiffs.bin
+	@echo $(ESPTOOL) --chip esp32 --baud $(BAUD0) --port $(PORT0) --before default_reset --after hard_reset write_flash -z --flash_mode qio --flash_freq 80m --flash_size detect $(SPIFFS_DATA_OFFSET) ./spiffs/mrbc.spiffs.bin
+	$(ESPTOOL) --chip esp32 --baud $(BAUD0) --port $(PORT0) --before default_reset --after hard_reset write_flash -z --flash_mode qio --flash_freq 80m --flash_size detect $(SPIFFS_DATA_OFFSET) ./spiffs/mrbc.spiffs.bin
 
 spiffs-clean:
 	@echo $(RM) ./spiffs/mrbc.spiffs.bin
@@ -73,4 +79,4 @@ store-vm:
 	cp build/bootloader/bootloader.bin ${FIRMWAREDIR}
 
 flash-vm:
-	$(ESPTOOL) --chip esp32 --baud 921600 --port $(PORT0) --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size detect $(SPIFFS_OTA_OFFSET) $(FIRMWAREDIR)/ota_data_initial.bin 0x1000 $(FIRMWAREDIR)/bootloader.bin $(SPIFFS_OTA0_OFFSET) $(FIRMWAREDIR)/mrubyc-esp32.bin 0x8000 $(FIRMWAREDIR)/partitions.bin
+	$(ESPTOOL) --chip esp32 --baud $(BAUD0) --port $(PORT0) --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size detect $(SPIFFS_OTA_OFFSET) $(FIRMWAREDIR)/ota_data_initial.bin 0x1000 $(FIRMWAREDIR)/bootloader.bin $(SPIFFS_OTA0_OFFSET) $(FIRMWAREDIR)/mrubyc-esp32.bin 0x8000 $(FIRMWAREDIR)/partitions.bin


### PR DESCRIPTION
環境変数 `BAUD` を参照して `make spiffs` を実行したときのレートを変更できるようにします。

詳細は #27 をご覧ください。