### PR TITLE
mrblibがない場合のmake失敗について #34

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,9 @@ SPIFFSFILE = $(PROJECT_PATH)/spiffs/mrbc.spiffs.bin
 .PHONY: spiffs flash monitor store-vm 
 
 all: $(OBJS)
+ifneq ("$(CLASSFILES)", "")
 	$(MRBC) -B $(MYCLASS) --remove-lv -o $(PROJECT_PATH)/main/mrblib.c  $(CLASSFILES)
+endif
 	$(IDFTOOL) build
 
 flash: all


### PR DESCRIPTION
追加のmrblibがない場合にmakeコマンドが失敗する問題を修正いたします。

本件の詳細については https://github.com/gfd-dennou-club/mrubyc-esp32/issues/34 をご覧ください。
