### PR TITLE
make flashとmake monitorでBAUDとPORTを指定する #37

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,10 +54,10 @@ all: $(OBJS)
 	$(IDFTOOL) build
 
 flash: all
-	$(IDFTOOL) flash
+	$(IDFTOOL) flash --baud $(BAUD0) --port $(PORT0)
 
 monitor:
-	$(IDFTOOL) monitor
+	$(IDFTOOL) monitor --monitor-baud $(BAUD0) --port $(PORT0)
 
 clean:
 	$(IDFTOOL) clean


### PR DESCRIPTION
make flashとmake monitorでBAUDとPORTが無視される問題を修正いたします。

本件の詳細については https://github.com/gfd-dennou-club/mrubyc-esp32/issues/37 をご覧ください。
